### PR TITLE
Fix toggle start/stop/start

### DIFF
--- a/library/src/main/api21/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/api21/com/google/android/cameraview/Camera2.java
@@ -77,6 +77,7 @@ class Camera2 extends CameraViewImpl {
 
         @Override
         public void onClosed(@NonNull CameraDevice camera) {
+            mCamera = null;
             mCallback.onCameraClosed();
         }
 


### PR DESCRIPTION
It appears that Camera2 wasn't cleaning up a reference to
the Camera object when closed. This caused an error when
toggling start/stop states. This commit the issue by simply
setting the camera object to null in Camera2.

Fixes google/cameraview/#146